### PR TITLE
Changed the position of DASH[ACT-R].md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ The following tables represent the weighted means and the 99% confidence interva
 | Algorithm | Log Loss | RMSE (bins) | Parameters |
 | --- | --- | --- | --- |
 | FSRS-4.5 | **0.32±0.006** | 0.043±0.0010 | 17 |
-| FSRS rs | 0.33±0.006 | 0.046±0.0011 | 17 |
 | DASH[ACT-R] | 0.33±0.005 | **0.039±0.0011** | 5 |
+| FSRS rs | 0.33±0.006 | 0.046±0.0011 | 17 |
 | FSRS v4 | 0.33±0.006 | 0.052±0.0014 | 17 |
 | DASH | 0.34±0.005 | 0.046±0.0011 | 9 |
 | DASH[MCM] | 0.34±0.005 | 0.049±0.0011 | 9 |


### PR DESCRIPTION
Here's my reasoning:
1) Sort by log loss
2) If there are ties (log loss of algorithm A is equal to log loss of algorithm B **after** rounding), sort them by RMSE. According to this reasoning, DASH[ACT-R] should be above FSRS-rs