### PR TITLE
use FSRS4.5+ forgetting curve for algos that do not have implicitly defined curve

### DIFF
--- a/other.py
+++ b/other.py
@@ -787,7 +787,7 @@ class RNN(nn.Module):
         return self.fc(h)
 
     def forgetting_curve(self, t, s):
-        return 0.9 ** (t / s)
+        return (1 + FACTOR * t / s) ** DECAY
 
 
 class GRU_P(nn.Module):
@@ -875,7 +875,7 @@ class Transformer(nn.Module):
         return output, None
 
     def forgetting_curve(self, t, s):
-        return 0.9 ** (t / s)
+        return (1 + FACTOR * t / s) ** DECAY
 
 
 class HLR(nn.Module):


### PR DESCRIPTION
Use FSRS4.5+ forgetting curve for algos that do not have implicitly defined curve.
This improves all of the NN based algos, but you will need to pretrain again.
Similar thing could be done for HLR which improves it as well, but it wouldn't be half life anymore, not sure if you would want to have 2 variants to see how forgetting curve alone impacts the same algo.