### PR TITLE
Add secs tests equalization

### DIFF
--- a/config.py
+++ b/config.py
@@ -40,6 +40,12 @@ def create_parser():
         help="exclude reviews with elapsed_days=0 from testset",
     )
 
+    parser.add_argument(
+        "--equalize_test_with_non_secs",
+        action="store_true",
+        help="Only test with reviews that would be included in non-secs tests",
+    )
+
     # save detailed results
     parser.add_argument("--raw", action="store_true", help="save raw predictions")
     parser.add_argument(


### PR DESCRIPTION
Adds --equalize_test_with_non_secs flag to test secs models on the same reviews as non-secs models.
See: https://github.com/open-spaced-repetition/srs-benchmark/issues/149.

```
Model: FSRS-5-secs-equalize_test_with_non_secs
Total number of users: 100
Total number of reviews: 2097825
Weighted average by reviews:
FSRS-5-secs-equalize_test_with_non_secs LogLoss (mean±std): 0.3841±0.1827
FSRS-5-secs-equalize_test_with_non_secs RMSE(bins) (mean±std): 0.0793±0.0377
FSRS-5-secs-equalize_test_with_non_secs AUC (mean±std): 0.6981±0.0752

Model: FSRS-5
Total number of users: 100
Total number of reviews: 2097825
Weighted average by reviews:
FSRS-5 LogLoss (mean±std): 0.3761±0.1779
FSRS-5 RMSE(bins) (mean±std): 0.0687±0.0339
FSRS-5 AUC (mean±std): 0.7080±0.0744

```