### PR TITLE
Fixed --equalize_test_with_non_secs after recent commit

### DIFF
--- a/other.py
+++ b/other.py
@@ -2703,7 +2703,7 @@ def create_features(df, model_name="FSRSv3"):
                 non_secs_test_set["review_th"]
             )
 
-        return df
+        return df_secs
     else:
         return create_features_helper(df, model_name, SECS_IVL)
 


### PR DESCRIPTION
The recent [commit](https://github.com/open-spaced-repetition/srs-benchmark/commit/0c3a2c818140fd52459792103d84a836530cb081) does a rename on df to df_secs but misses the return. This PR fixes it.