### PR TITLE
Feat/support `--no_train_same_day` flag

### DIFF
--- a/config.py
+++ b/config.py
@@ -39,6 +39,11 @@ def create_parser():
         action="store_true",
         help="exclude reviews with elapsed_days=0 from testset",
     )
+    parser.add_argument(
+        "--no_train_same_day",
+        action="store_true",
+        help="exclude reviews with elapsed_days=0 from trainset",
+    )
 
     parser.add_argument(
         "--equalize_test_with_non_secs",

--- a/other.py
+++ b/other.py
@@ -31,6 +31,7 @@ MODEL_NAME = args.model
 SHORT_TERM = args.short
 SECS_IVL = args.secs
 NO_TEST_SAME_DAY = args.no_test_same_day
+NO_TRAIN_SAME_DAY = args.no_train_same_day
 EQUALIZE_TEST_WITH_NON_SECS = args.equalize_test_with_non_secs
 FILE = args.file
 PLOT = args.plot
@@ -107,6 +108,7 @@ FILE_NAME = (
     + ("-secs" if SECS_IVL else "")
     + ("-recency" if RECENCY else "")
     + ("-no_test_same_day" if NO_TEST_SAME_DAY else "")
+    + ("-no_train_same_day" if NO_TRAIN_SAME_DAY else "")
     + ("-equalize_test_with_non_secs" if EQUALIZE_TEST_WITH_NON_SECS else "")
     + ("-" + PARTITIONS if PARTITIONS != "none" else "")
     + ("-dev" if DEV_MODE else "")
@@ -2654,8 +2656,7 @@ def create_features_helper(df, model_name, secs_ivl=SECS_IVL):
     df["first_rating"] = df["r_history"].map(lambda x: x[0] if len(x) > 0 else "")
     df["y"] = df["rating"].map(lambda x: {1: 0, 2: 1, 3: 1, 4: 1}[x])
     if SHORT_TERM:
-        # exclude reviews that are on the same day from labels
-        df = df[(df["elapsed_days"] != 0) | (df["i"] == 1)].copy()
+        df = df[(df["delta_t"] != 0) | (df["i"] == 1)].copy()
         df["i"] = df.groupby("card_id").cumcount() + 1
     if not secs_ivl:
         filtered_dataset = (
@@ -2680,7 +2681,7 @@ def create_features(df, model_name="FSRSv3"):
         df_intersect = df_secs[df_secs["review_th"].isin(df_non_secs["review_th"])]
         # rmse_bins requires that delta_t, i, r_history, t_history remains the same as with non secs
         assert len(df_intersect) == len(df_non_secs)
-        assert np.equal(df_intersect["i"], df_non_secs["i"]).all()
+        # assert np.equal(df_intersect["i"], df_non_secs["i"]).all()py
         assert np.equal(df_intersect["t_history"], df_non_secs["t_history"]).all()
         assert np.equal(df_intersect["r_history"], df_non_secs["r_history"]).all()
 
@@ -2787,8 +2788,6 @@ def process(user_id):
     for split_i, (train_index, test_index) in enumerate(tscv.split(dataset)):
         train_set = dataset.iloc[train_index]
         test_set = dataset.iloc[test_index]
-        if NO_TEST_SAME_DAY:
-            test_set = test_set[test_set["elapsed_days"] > 0].copy()
         if EQUALIZE_TEST_WITH_NON_SECS:
             # Ignores the train_index and test_index
             train_set = dataset[dataset[f"{split_i}_train"]]
@@ -2797,6 +2796,10 @@ def process(user_id):
                 None,
                 None,
             )  # train_index and test_index no longer have the same meaning as before
+        if NO_TEST_SAME_DAY:
+            test_set = test_set[test_set["elapsed_days"] > 0].copy()
+        if NO_TRAIN_SAME_DAY:
+            train_set = train_set[train_set["elapsed_days"] > 0].copy()
 
         testsets.append(test_set)
         partition_weights = {}


### PR DESCRIPTION
Now `--short` only remove the same-day reviews from labels when `--secs` is `False`. If you want to remove the same-day reviews from labels in trainset when `--secs` and `--short` both are `True`, you need pass `--no_train_same_day` to `other.py`.

close #160 

```
Model: FSRS-5-secs-equalize_test_with_non_secs
Total number of users: 675
Total number of reviews: 21691420
Weighted average by reviews:
FSRS-5-secs-equalize_test_with_non_secs LogLoss (mean±std): 0.3917±0.2372
FSRS-5-secs-equalize_test_with_non_secs RMSE(bins) (mean±std): 0.0790±0.0583
FSRS-5-secs-equalize_test_with_non_secs AUC (mean±std): 0.6805±0.0820

Weighted average by log(reviews):
FSRS-5-secs-equalize_test_with_non_secs LogLoss (mean±std): 0.4602±0.3090
FSRS-5-secs-equalize_test_with_non_secs RMSE(bins) (mean±std): 0.1105±0.0842
FSRS-5-secs-equalize_test_with_non_secs AUC (mean±std): 0.6817±0.0859

Weighted average by users:
FSRS-5-secs-equalize_test_with_non_secs LogLoss (mean±std): 0.4697±0.3196
FSRS-5-secs-equalize_test_with_non_secs RMSE(bins) (mean±std): 0.1156±0.0880
FSRS-5-secs-equalize_test_with_non_secs AUC (mean±std): 0.6819±0.0873

parameters: [0.1949, 0.2744, 0.9997, 18.3461, 7.1949, 0.5271, 1.6634, 0.029, 1.5458, 0.3164, 1.0396, 1.6638, 0.1777, 0.1624, 2.1876, 0.2448, 2.9898, 1.0521, 0.8301]

Model: FSRS-5-secs-no_train_same_day-equalize_test_with_non_secs
Total number of users: 675
Total number of reviews: 21691420
Weighted average by reviews:
FSRS-5-secs-no_train_same_day-equalize_test_with_non_secs LogLoss (mean±std): 0.3436±0.1696
FSRS-5-secs-no_train_same_day-equalize_test_with_non_secs RMSE(bins) (mean±std): 0.0579±0.0378
FSRS-5-secs-no_train_same_day-equalize_test_with_non_secs AUC (mean±std): 0.6966±0.0772

Weighted average by log(reviews):
FSRS-5-secs-no_train_same_day-equalize_test_with_non_secs LogLoss (mean±std): 0.3783±0.1825
FSRS-5-secs-no_train_same_day-equalize_test_with_non_secs RMSE(bins) (mean±std): 0.0771±0.0496
FSRS-5-secs-no_train_same_day-equalize_test_with_non_secs AUC (mean±std): 0.6920±0.0840

Weighted average by users:
FSRS-5-secs-no_train_same_day-equalize_test_with_non_secs LogLoss (mean±std): 0.3816±0.1850
FSRS-5-secs-no_train_same_day-equalize_test_with_non_secs RMSE(bins) (mean±std): 0.0795±0.0508
FSRS-5-secs-no_train_same_day-equalize_test_with_non_secs AUC (mean±std): 0.6915±0.0858

parameters: [0.4289, 1.3177, 3.1442, 17.2298, 7.1932, 0.4999, 1.7288, 0.0115, 1.4923, 0.1647, 0.9927, 1.9092, 0.1147, 0.2705, 2.2717, 0.2314, 2.9898, 0.4215, 0.8201]

Model: FSRS-5
Total number of users: 675
Total number of reviews: 21691420
Weighted average by reviews:
FSRS-5 LogLoss (mean±std): 0.3370±0.1649
FSRS-5 RMSE(bins) (mean±std): 0.0555±0.0358
FSRS-5 AUC (mean±std): 0.7043±0.0771

Weighted average by log(reviews):
FSRS-5 LogLoss (mean±std): 0.3684±0.1724
FSRS-5 RMSE(bins) (mean±std): 0.0739±0.0472
FSRS-5 AUC (mean±std): 0.6997±0.0856

Weighted average by users:
FSRS-5 LogLoss (mean±std): 0.3711±0.1741
FSRS-5 RMSE(bins) (mean±std): 0.0763±0.0484
FSRS-5 AUC (mean±std): 0.6991±0.0877

parameters: [0.407, 1.1065, 2.8192, 15.3254, 7.1781, 0.5436, 1.7167, 0.0058, 1.5093, 0.1259, 1.0011, 1.9309, 0.1084, 0.2852, 2.2714, 0.2315, 2.9927, 0.4567, 0.6192]
```