### PR TITLE
Don't load unused columns

### DIFF
--- a/script.py
+++ b/script.py
@@ -235,7 +235,9 @@ def process(user_id):
     if SECS_IVL:
         columns.append("elapsed_seconds")
     df_revlogs = pd.read_parquet(
-        DATA_PATH / "revlogs", filters=[("user_id", "=", user_id), ("rating", "in", [1, 2, 3, 4])], columns=columns 
+        DATA_PATH / "revlogs",
+        filters=[("user_id", "=", user_id), ("rating", "in", [1, 2, 3, 4])],
+        columns=columns,
     )
     dataset = create_time_series(df_revlogs)
     if dataset.shape[0] < 6:

--- a/script.py
+++ b/script.py
@@ -231,13 +231,11 @@ def create_time_series(df):
 @catch_exceptions
 def process(user_id):
     plt.close("all")
-    columns = ["card_id", "day_offset", "rating", "elapsed_days"]
+    columns = ["card_id", "rating", "elapsed_days"]
     if SECS_IVL:
         columns.append("elapsed_seconds")
     df_revlogs = pd.read_parquet(
-        DATA_PATH / "revlogs",
-        filters=[("user_id", "=", user_id), ("rating", "in", [1, 2, 3, 4])],
-        columns=columns,
+        DATA_PATH / "revlogs", filters=[("user_id", "=", user_id), ("rating", "in", [1, 2, 3, 4])], columns=columns 
     )
     dataset = create_time_series(df_revlogs)
     if dataset.shape[0] < 6:

--- a/script.py
+++ b/script.py
@@ -167,7 +167,6 @@ def cum_concat(x):
 def create_time_series(df):
     df["review_th"] = range(1, df.shape[0] + 1)
     df.sort_values(by=["card_id", "review_th"], inplace=True)
-    df.drop(df[~df["rating"].isin([1, 2, 3, 4])].index, inplace=True)
     df["i"] = df.groupby("card_id").cumcount() + 1
     df.drop(df[df["i"] > max_seq_len * 2].index, inplace=True)
     card_id_to_first_rating = df.groupby("card_id")["rating"].first().to_dict()
@@ -237,7 +236,7 @@ def create_time_series(df):
 def process(user_id):
     plt.close("all")
     df_revlogs = pd.read_parquet(
-        DATA_PATH / "revlogs", filters=[("user_id", "=", user_id)]
+        DATA_PATH / "revlogs", filters=[("user_id", "=", user_id), ("rating", "in", [1, 2, 3, 4])]
     )
     dataset = create_time_series(df_revlogs)
     if dataset.shape[0] < 6:


### PR DESCRIPTION
(Also moves the "rating" drop into the read_parquet filter)
Seems to help with memory usage:

![column filter](https://github.com/user-attachments/assets/78979f04-88d0-419d-a3b9-f709952195d4)
![filter columns](https://github.com/user-attachments/assets/fd83a2bd-a98e-42dd-b03e-647bd6ea3eaa)

Can't filter `elapsed_days` on secs because of:
https://github.com/open-spaced-repetition/srs-benchmark/blob/b6ae34dcff0146a2a2af192a177964b784d88f26/script.py#L270-L271

--secs:
![--secs](https://github.com/user-attachments/assets/b0f156bb-4cb3-4d22-bd50-5f41df5c7dfe)

Tested with: https://github.com/Luc-Mcgrady/srs-benchmark/blob/pq-filters-test/performance.py
