### PR TITLE
Added a taxonomy of algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We use three metrics in the SRS benchmark to evaluate how well these algorithms 
 
 Log Loss and RMSE (bins) measure calibration: how well predicted probabilities of recall match the real data. AUC measures discrimination: how well the algorithm can tell two (or more, generally speaking) classes apart. AUC can be good (high) even if Log Loss and RMSE are poor.
 
-### Algorithms
+### Algorithms and algorithm families
 
 - DSR: **D**ifficulty, **S**tability, **R**etrievability model of memory. Sometimes the difficulty variable is excluded.
     - FSRS v1 and v2: the initial experimental versions of FSRS.

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Then run the following command:
 python script.py --rust
 ```
 
-Dev model in fsrs-optimizer:
+Dev algorithm in fsrs-optimizer:
 
 ```bash
 python script.py --dev
@@ -311,7 +311,7 @@ python script.py --plot
 Benchmark FSRSv4/FSRSv3/HLR/LSTM/SM2:
 
 ```bash
-python other.py --model FSRSv4
+python other.py --algo FSRSv4
 ```
 
-> Please change the `--model` argument to `FSRSv3`, `HLR`, `GRU`, or `SM2` to run the corresponding algorithm.
+> Please change the `--algo` argument to `FSRSv3`, `HLR`, `LSTM`, or `SM2` to run the corresponding algorithm.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Log Loss and RMSE (bins) measure calibration: how well predicted probabilities o
 
 ### Algorithms and algorithm families
 
-- DSR **D**ifficulty, **S**tability, **R**etrievability model of memory:
+- DSR (**D**ifficulty, **S**tability, **R**etrievability) model of memory:
     - FSRS v1 and v2: the initial experimental versions of FSRS.
     - FSRS v3: the first official release of the FSRS algorithm, made available as a custom scheduling script.
     - FSRS v4: the upgraded version of FSRS, made better with help from the community.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Log Loss and RMSE (bins) measure calibration: how well predicted probabilities o
 
 ### Algorithms and algorithm families
 
-- DSR: **D**ifficulty, **S**tability, **R**etrievability model of memory. Sometimes the difficulty variable is excluded.
+- DSR **D**ifficulty, **S**tability, **R**etrievability model of memory:
     - FSRS v1 and v2: the initial experimental versions of FSRS.
     - FSRS v3: the first official release of the FSRS algorithm, made available as a custom scheduling script.
     - FSRS v4: the upgraded version of FSRS, made better with help from the community.
@@ -48,24 +48,24 @@ Log Loss and RMSE (bins) measure calibration: how well predicted probabilities o
     - HLR: the algorithm proposed by Duolingo. Its full name is Half-Life Regression. For further information, please refer to the [this paper](https://github.com/duolingo/halflife-regression).
     - Ebisu v2: [an algorithm that uses Bayesian statistics](https://fasiha.github.io/ebisu/) to update its estimate of memory half-life after every review.
 
-- Alternative models of memory.
+- Alternative models of memory:
     - DASH: the algorithm proposed in [this paper](https://scholar.colorado.edu/concern/graduate_thesis_or_dissertations/zp38wc97m). The name stands for Difficulty, Ability, and Study History. In our benchmark, we only use the Ability and Study History because the Difficulty part is not applicable to our dataset. We also added two other variants of this algorithm: DASH[MCM] and DASH[ACT-R]. For further information, please refer to [this paper](https://www.politesi.polimi.it/retrieve/b39227dd-0963-40f2-a44b-624f205cb224/2022_4_Randazzo_01.pdf).
     - ACT-R: the algorithm proposed in [this paper](http://act-r.psy.cmu.edu/wordpress/wp-content/themes/ACT-R/workshops/2003/proceedings/46.pdf). It includes an activation-based system of declarative memory. It explains the spacing effect by the activation of memory traces.
 
-- Neural networks.
+- Neural networks:
     - Transformer: a type of neural network that has gained popularity in recent years due to its superior performance in natural language processing. ChatGPT is based on this architecture.
     - GRU: a type of recurrent neural network that's often used for making predictions based on a sequence of data. It's a classic in the field of machine learning for time-related tasks. Both GRU and Transformer use the same power forgetting curve as FSRS-4.5 and FSRS-5 to make the comparison more fair.
         - GRU-P: a variant of GRU that removes the fixed forgetting curve and predicts the probability of recall directly. This makes it more flexible than GRU, but also more prone to making strange predictions, such as the probability of recall *increasing* over time.
     - LSTM: a recurrent neural network with a more complex and sophisticated architecture than GRU. It is trained using the [Reptile algorithm](https://openai.com/index/reptile/). It uses short-term reviews, fractional intervals, and the duration of review as part of its input. It must be fine-tuned on some data before it can be used.
     - NN-17: a neural network approximation of [SM-17](https://supermemo.guru/wiki/Algorithm_SM-17). It has a comparable number of parameters, and according to our estimates, it performs similarly to SM-17.
 
-- SM-2-based algorithms. Originally, they weren't designed to predict the probability of recall.
+- SM-2-based algorithms:
     - SM-2: one of the early algorithms used by SuperMemo, the first spaced repetition software. It was developed more than 30 years ago, and it's still popular today. [Anki's default algorithm is based on SM-2](https://faqs.ankiweb.net/what-spaced-repetition-algorithm.html), [Mnemosyne](https://mnemosyne-proj.org/principles.php) also uses it. This algorithm does not predict the probability of recall natively; therefore, for the sake of the benchmark, the output was modified based on some assumptions about the forgetting curve. The algorithm is described by Piotr Wozniak [here](https://super-memory.com/english/ol/sm2.htm).
         - SM-2 trainable: SM-2 algorithm with optimizable parameters.
     - Anki-SM-2: a variant of the SM-2 algorithm that is used in Anki.
         - Anki-SM-2 trainable: Anki algorithm with optimizable parameters.
 
-- Other.
+- Other:
     - AVG: an "algorithm" that outputs a constant equal to the user's average retention. Has no practical applications and is intended only to serve as a baseline.
     - RMSE-BINS-EXPLOIT: an algorithm that exploits the calculation of RMSE (bins) by simulating the bins and keeping the error term close to 0.
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ Log Loss and RMSE (bins) measure calibration: how well predicted probabilities o
     - NN-17: a neural network approximation of [SM-17](https://supermemo.guru/wiki/Algorithm_SM-17). It has a comparable number of parameters, and according to our estimates, it performs similarly to SM-17.
 
 - SM-2-based algorithms. Originally, they weren't designed to predict the probability of recall.
-- SM-2: one of the early algorithms used by SuperMemo, the first spaced repetition software. It was developed more than 30 years ago, and it's still popular today. [Anki's default algorithm is based on SM-2](https://faqs.ankiweb.net/what-spaced-repetition-algorithm.html), [Mnemosyne](https://mnemosyne-proj.org/principles.php) also uses it. This algorithm does not predict the probability of recall natively; therefore, for the sake of the benchmark, the output was modified based on some assumptions about the forgetting curve. The algorithm is described by Piotr Wozniak [here](https://super-memory.com/english/ol/sm2.htm).
-  - SM-2 trainable: SM-2 algorithm with optimizable parameters.
-- Anki-SM-2: a variant of the SM-2 algorithm that is used in Anki.
-  - Anki-SM-2 trainable: Anki algorithm with optimizable parameters.
+    - SM-2: one of the early algorithms used by SuperMemo, the first spaced repetition software. It was developed more than 30 years ago, and it's still popular today. [Anki's default algorithm is based on SM-2](https://faqs.ankiweb.net/what-spaced-repetition-algorithm.html), [Mnemosyne](https://mnemosyne-proj.org/principles.php) also uses it. This algorithm does not predict the probability of recall natively; therefore, for the sake of the benchmark, the output was modified based on some assumptions about the forgetting curve. The algorithm is described by Piotr Wozniak [here](https://super-memory.com/english/ol/sm2.htm).
+        - SM-2 trainable: SM-2 algorithm with optimizable parameters.
+    - Anki-SM-2: a variant of the SM-2 algorithm that is used in Anki.
+        - Anki-SM-2 trainable: Anki algorithm with optimizable parameters.
 
 - Other.
     - AVG: an "algorithm" that outputs a constant equal to the user's average retention. Has no practical applications and is intended only to serve as a baseline.

--- a/README.md
+++ b/README.md
@@ -32,33 +32,42 @@ Log Loss and RMSE (bins) measure calibration: how well predicted probabilities o
 
 ### Algorithms
 
-- FSRS v1 and v2: the initial experimental versions of FSRS.
-- FSRS v3: the first official release of the FSRS algorithm, made available as a custom scheduling script.
-- FSRS v4: the upgraded version of FSRS, made better with help from the community.
-- FSRS-4.5: the minorly improved version based on FSRS v4. The shape of the forgetting curve has been changed.
-- FSRS-5: the latest version of FSRS. Unlike the previous versions, it uses the same-day review data. Same-day reviews are used only for training, and not for evaluation.
-    - FSRS-5 default param.: FSRS-5 with default parameters. The default parameters have been obtained by running FSRS-5 on all 20 thousand collections from the *previous* dataset and calculating the median of each parameter.
-    - FSRS-5 pretrain: FSRS-5 where only the first 4 parameters (values of initial stability after the first review) are optimized and the rest are set to default.
-    - FSRS-5 binary: FSRS which treats `hard` and `easy` grades as `good`.
-    - FSRS-5 preset: different parameters are used for each preset. The minimum number of presets in Anki is one, a preset can be applied to multiple decks.
-    - FSRS-5 deck: different parameters are used for each deck.
-    - FSRS-5 recency: FSRS-5 trained with reviews being weighted based on their recency, such that older reviews affect the loss function less and newer reviews affect it more.
-- FSRS-rs: the Rust port of FSRS-5. See also: https://github.com/open-spaced-repetition/fsrs-rs
-- GRU: a type of recurrent neural network that's often used for making predictions based on a sequence of data. It's a classic in the field of machine learning for time-related tasks.
-    - GRU-P: a variant of GRU that removes the fixed forgetting curve and predicts the probability of recall directly. This makes it more flexible than GRU, but also more prone to making strange predictions, such as the probability of recall *increasing* over time.
-- LSTM: a recurrent neural network with a more complex and sophisticated architecture than GRU. It is trained using the [Reptile algorithm](https://openai.com/index/reptile/). It uses short-term reviews, fractional intervals, and the duration of review as part of its input. It must be fine-tuned on some data before it can be used.
-- DASH: the model proposed in [this paper](https://scholar.colorado.edu/concern/graduate_thesis_or_dissertations/zp38wc97m). The name stands for Difficulty, Ability, and Study History. In our benchmark, we only use the Ability and Study History because the Difficulty part is not applicable to our dataset. We also added two other variants of this model: DASH[MCM] and DASH[ACT-R]. For further information, please refer to [this paper](https://www.politesi.polimi.it/retrieve/b39227dd-0963-40f2-a44b-624f205cb224/2022_4_Randazzo_01.pdf).
-- ACT-R: the model proposed in [this paper](http://act-r.psy.cmu.edu/wordpress/wp-content/themes/ACT-R/workshops/2003/proceedings/46.pdf). It includes an activation-based system of declarative memory. It explains the spacing effect by the activation of memory traces.
-- HLR: the model proposed by Duolingo. Its full name is Half-Life Regression. For further information, please refer to the [this paper](https://github.com/duolingo/halflife-regression).
-- Transformer: a type of neural network that has gained popularity in recent years due to its superior performance in natural language processing. ChatGPT is based on this architecture. Both GRU and Transformer use the same power forgetting curve as FSRS-4.5 and FSRS-5 to make the comparison more fair.
+- DSR: **D**ifficulty, **S**tability, **R**etrievability model of memory. Sometimes the difficulty variable is excluded.
+    - FSRS v1 and v2: the initial experimental versions of FSRS.
+    - FSRS v3: the first official release of the FSRS algorithm, made available as a custom scheduling script.
+    - FSRS v4: the upgraded version of FSRS, made better with help from the community.
+    - FSRS-4.5: the minorly improved version based on FSRS v4. The shape of the forgetting curve has been changed.
+    - FSRS-5: the latest version of FSRS. Unlike the previous versions, it uses the same-day review data. Same-day reviews are used only for training, and not for evaluation.
+        - FSRS-5 default param.: FSRS-5 with default parameters. The default parameters have been obtained by running FSRS-5 on all 20 thousand collections from the *previous* dataset and calculating the median of each parameter.
+        - FSRS-5 pretrain: FSRS-5 where only the first 4 parameters (values of initial stability after the first review) are optimized and the rest are set to default.
+        - FSRS-5 binary: FSRS which treats `hard` and `easy` grades as `good`.
+        - FSRS-5 preset: different parameters are used for each preset. The minimum number of presets in Anki is one, a preset can be applied to multiple decks.
+        - FSRS-5 deck: different parameters are used for each deck.
+        - FSRS-5 recency: FSRS-5 trained with reviews being weighted based on their recency, such that older reviews affect the loss function less and newer reviews affect it more.
+    - FSRS-rs: the Rust port of FSRS-5. See also: https://github.com/open-spaced-repetition/fsrs-rs
+    - HLR: the algorithm proposed by Duolingo. Its full name is Half-Life Regression. For further information, please refer to the [this paper](https://github.com/duolingo/halflife-regression).
+    - Ebisu v2: [an algorithm that uses Bayesian statistics](https://fasiha.github.io/ebisu/) to update its estimate of memory half-life after every review.
+
+- Alternative models of memory.
+    - DASH: the algorithm proposed in [this paper](https://scholar.colorado.edu/concern/graduate_thesis_or_dissertations/zp38wc97m). The name stands for Difficulty, Ability, and Study History. In our benchmark, we only use the Ability and Study History because the Difficulty part is not applicable to our dataset. We also added two other variants of this algorithm: DASH[MCM] and DASH[ACT-R]. For further information, please refer to [this paper](https://www.politesi.polimi.it/retrieve/b39227dd-0963-40f2-a44b-624f205cb224/2022_4_Randazzo_01.pdf).
+    - ACT-R: the algorithm proposed in [this paper](http://act-r.psy.cmu.edu/wordpress/wp-content/themes/ACT-R/workshops/2003/proceedings/46.pdf). It includes an activation-based system of declarative memory. It explains the spacing effect by the activation of memory traces.
+
+- Neural networks.
+    - Transformer: a type of neural network that has gained popularity in recent years due to its superior performance in natural language processing. ChatGPT is based on this architecture.
+    - GRU: a type of recurrent neural network that's often used for making predictions based on a sequence of data. It's a classic in the field of machine learning for time-related tasks. Both GRU and Transformer use the same power forgetting curve as FSRS-4.5 and FSRS-5 to make the comparison more fair.
+        - GRU-P: a variant of GRU that removes the fixed forgetting curve and predicts the probability of recall directly. This makes it more flexible than GRU, but also more prone to making strange predictions, such as the probability of recall *increasing* over time.
+    - LSTM: a recurrent neural network with a more complex and sophisticated architecture than GRU. It is trained using the [Reptile algorithm](https://openai.com/index/reptile/). It uses short-term reviews, fractional intervals, and the duration of review as part of its input. It must be fine-tuned on some data before it can be used.
+    - NN-17: a neural network approximation of [SM-17](https://supermemo.guru/wiki/Algorithm_SM-17). It has a comparable number of parameters, and according to our estimates, it performs similarly to SM-17.
+
+- SM-2-based algorithms. Originally, they weren't designed to predict the probability of recall.
 - SM-2: one of the early algorithms used by SuperMemo, the first spaced repetition software. It was developed more than 30 years ago, and it's still popular today. [Anki's default algorithm is based on SM-2](https://faqs.ankiweb.net/what-spaced-repetition-algorithm.html), [Mnemosyne](https://mnemosyne-proj.org/principles.php) also uses it. This algorithm does not predict the probability of recall natively; therefore, for the sake of the benchmark, the output was modified based on some assumptions about the forgetting curve. The algorithm is described by Piotr Wozniak [here](https://super-memory.com/english/ol/sm2.htm).
   - SM-2 trainable: SM-2 algorithm with optimizable parameters.
 - Anki-SM-2: a variant of the SM-2 algorithm that is used in Anki.
   - Anki-SM-2 trainable: Anki algorithm with optimizable parameters.
-- NN-17: a neural network approximation of [SM-17](https://supermemo.guru/wiki/Algorithm_SM-17). It has a comparable number of parameters, and according to our estimates, it performs similarly to SM-17.
-- Ebisu v2: [an algorithm that uses Bayesian statistics](https://fasiha.github.io/ebisu/) to update its estimate of memory half-life after every review.
-- AVG: an "algorithm" that outputs a constant equal to the user's average retention. Has no practical applications and is intended only to serve as a baseline.
-- RMSE-BINS-EXPLOIT: an algorithm that exploits the calculation of RMSE (bins) by simulating the bins and keeping the error term close to 0.
+
+- Other.
+    - AVG: an "algorithm" that outputs a constant equal to the user's average retention. Has no practical applications and is intended only to serve as a baseline.
+    - RMSE-BINS-EXPLOIT: an algorithm that exploits the calculation of RMSE (bins) by simulating the bins and keeping the error term close to 0.
 
 For further information regarding the FSRS algorithm, please refer to the following wiki page: [The Algorithm](https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm).
 
@@ -85,7 +94,7 @@ For the sake of brevity, the following abbreviations are used in the "Input feat
 
 ### Weighted by the number of reviews
 
-| Model | Parameters | Log Loss | RMSE (bins) | AUC | Input features |
+| Algorithm | Parameters | Log Loss | RMSE (bins) | AUC | Input features |
 | --- | --- | --- | --- | --- | --- |
 | **LSTM** | 8869 | **0.312±0.0078** | 0.035±0.0011 | **0.733±0.0038** | FIL, G, SR, AT |
 | GRU-P-short | 297 | 0.320±0.0080 | 0.042±0.0013 | 0.710±0.0047 | IL, G, SR|
@@ -124,7 +133,7 @@ For the sake of brevity, the following abbreviations are used in the "Input feat
 
 ### Unweighted
 
-| Model | Parameters | Log Loss | RMSE (bins) | AUC | Input features |
+| Algorithm | Parameters | Log Loss | RMSE (bins) | AUC | Input features |
 | --- | --- | --- | --- | --- | --- |
 | **LSTM** | 8869 | **0.333±0.0042** | 0.0538±0.00096 | **0.733±0.0021** | FIL, G, SR, AT |
 | GRU-P-short | 297 | 0.346±0.0042 | 0.062±0.0011 | 0.699±0.0026 | IL, G, SR|
@@ -305,4 +314,4 @@ Benchmark FSRSv4/FSRSv3/HLR/LSTM/SM2:
 python other.py --model FSRSv4
 ```
 
-> Please change the `--model` argument to `FSRSv3`, `HLR`, `GRU`, or `SM2` to run the corresponding model.
+> Please change the `--model` argument to `FSRSv3`, `HLR`, `GRU`, or `SM2` to run the corresponding algorithm.

--- a/config.py
+++ b/config.py
@@ -65,7 +65,7 @@ def create_parser():
     )
 
     # other.py only
-    parser.add_argument("--model", default="FSRSv3", help="model name")
+    parser.add_argument("--algo", default="FSRSv3", help="algorithm name")
     parser.add_argument(
         "--short", action="store_true", help="include short-term reviews"
     )

--- a/other.py
+++ b/other.py
@@ -30,7 +30,7 @@ args = parser.parse_args()
 
 DEV_MODE = args.dev
 DRY_RUN = args.dry
-MODEL_NAME = args.model
+MODEL_NAME = args.algo
 SHORT_TERM = args.short
 SECS_IVL = args.secs
 NO_TEST_SAME_DAY = args.no_test_same_day
@@ -125,6 +125,12 @@ S_MAX = 36500
 
 
 class FSRS(nn.Module):
+    def __init__(self):
+        super(FSRS, self).__init__()
+
+    def forgetting_curve(self, t, s):
+        raise NotImplementedError("Forgetting curve not implemented")
+
     def iter(
         self,
         sequences: Tensor,
@@ -2345,7 +2351,7 @@ class Trainer:
     ) -> None:
         self.model = MODEL.to(device=DEVICE)
         if isinstance(MODEL, (FSRS4, FSRS4dot5, FSRS5)):
-            self.model.pretrain(train_set)
+            self.model.pretrain(train_set)  # type: ignore
         if isinstance(MODEL, (RNN, Transformer, GRU_P)):
             self.optimizer = torch.optim.AdamW(
                 self.model.parameters(), lr=lr, weight_decay=wd

--- a/significance_table.py
+++ b/significance_table.py
@@ -220,7 +220,6 @@ if __name__ == "__main__":
     models[index_sm2_short] = "SM-2-short"
     models[index_Ebisu_v2] = "Ebisu v2"
 
-    
     fig, ax = plt.subplots(figsize=(16, 16), dpi=200)
     ax.set_title(
         f"Wilcoxon signed-rank test, r-values ({n_collections} collections)",


### PR DESCRIPTION
I systematized the algorithms based on their architecture. Also, the usage of "algorithm" and "model" was inconsistent, so I made it more consistent.
To make it even more consistent, Jarrett, I suggest replacing `--model` with `--algo`