### PR TITLE
Fix/Ignore extra return from FSRSv1

### DIFF
--- a/other.py
+++ b/other.py
@@ -139,7 +139,7 @@ class FSRS(nn.Module):
         real_batch_size: int,
     ) -> dict[str, Tensor]:
         outputs, _ = self.forward(sequences)
-        stabilities, difficulties = outputs[
+        stabilities, difficulties, *_ = outputs[
             seq_lens - 1,
             torch.arange(real_batch_size, device=DEVICE),
         ].transpose(0, 1)


### PR DESCRIPTION
Running
```
python other.py --algo FSRSv1
```
raises an error.