### PR TITLE
set_num_threads to 1

### DIFF
--- a/other.py
+++ b/other.py
@@ -47,8 +47,8 @@ PROCESSES = args.processes
 DATA_PATH = Path(args.data)
 RECENCY = args.recency
 TRAIN_EQUALS_TEST = args.train_equals_test
-torch.set_num_threads(2)
-# torch.set_num_interop_threads(2)
+torch.set_num_threads(1)
+# torch.set_num_interop_threads(1)
 
 model_list = (
     "FSRSv1",

--- a/script.py
+++ b/script.py
@@ -35,8 +35,8 @@ PROCESSES = args.processes
 DATA_PATH = Path(args.data)
 DISABLE_SHORT_TERM = args.disable_short_term
 
-torch.set_num_threads(2)
-# torch.set_num_interop_threads(2)
+torch.set_num_threads(1)
+# torch.set_num_interop_threads(1)
 
 if DEV_MODE:
     # for local development


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/304c4714-e81a-4ebc-8fd3-9c8982977660)
![image](https://github.com/user-attachments/assets/519fe317-0850-48ca-924f-216858ffaf1e)
Based on these two screenshots you would not be able to guess which one was done with `torch.set_num_threads(1)` and which one with `torch.set_num_threads(2)`. Let's set it to 1 then. It's better to use `torch.set_num_threads(1)` and use more `--processes`