### PR TITLE
Added ranking

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -292,7 +292,7 @@ if __name__ == "__main__":
 
             # Step 4: Print the sorted table
             print(
-                "| Model | #Params | Rank | LogLoss | RMSE(bins) | AUC | Input features |"
+                "| Model | Parameters | Rank | LogLoss | RMSE(bins) | AUC | Input features |"
             )
             print("| --- | --- | --- | --- | --- | --- | --- |")
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -292,7 +292,7 @@ if __name__ == "__main__":
 
             # Step 4: Print the sorted table
             print(
-                "| Model | Parameters | Rank | LogLoss | RMSE(bins) | AUC | Input features |"
+                "| Algorithm | Parameters | Rank | LogLoss | RMSE(bins) | AUC | Input features |"
             )
             print("| --- | --- | --- | --- | --- | --- | --- |")
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -71,11 +71,13 @@ def weighted_avg_and_std(values, weights):
     average = np.average(values, weights=weights)
     # Bevington, P. R., Data Reduction and Error Analysis for the Physical Sciences, 336 pp., McGraw-Hill, 1969
     n_eff = np.square(np.sum(weights)) / np.sum(np.square(weights))
-    if n_eff <= 1:  # Avoid division by zero or negative number if there's only one effective sample
+    if (
+        n_eff <= 1
+    ):  # Avoid division by zero or negative number if there's only one effective sample
         variance = np.average((values - average) ** 2, weights=weights)
     else:
         variance = np.average((values - average) ** 2, weights=weights) * (
-                n_eff / (n_eff - 1)
+            n_eff / (n_eff - 1)
         )
     return (average, np.sqrt(variance))
 
@@ -194,9 +196,9 @@ if __name__ == "__main__":
             print(f"Total number of users: {len(sizes)}")
             print(f"Total number of reviews: {sum(sizes)}")
             for scale, size in (
-                    ("reviews", np.array(sizes)),
-                    ("log(reviews)", np.log(sizes)),
-                    ("users", np.ones_like(sizes)),
+                ("reviews", np.array(sizes)),
+                ("log(reviews)", np.log(sizes)),
+                ("users", np.ones_like(sizes)),
             ):
                 print(f"Weighted average by {scale}:")
                 for metric in ("LogLoss", "RMSE(bins)", "AUC"):
@@ -236,12 +238,14 @@ if __name__ == "__main__":
                 if len(sizes) == 0:
                     continue
 
-                size_weights = np.array(sizes) if scale == "reviews" else np.ones_like(sizes)
+                size_weights = (
+                    np.array(sizes) if scale == "reviews" else np.ones_like(sizes)
+                )
 
                 model_metrics = {
                     "model": model,
                     "n_param": n_param,
-                    "input_features": input_features
+                    "input_features": input_features,
                 }
 
                 for metric in ("LogLoss", "RMSE(bins)", "AUC"):
@@ -254,8 +258,12 @@ if __name__ == "__main__":
                     if len(metrics_filtered) == 0:
                         wmean, CI = np.nan, np.nan
                     else:
-                        wmean, wstd = weighted_avg_and_std(metrics_filtered, size_weights_filtered)
-                        CI = confidence_interval(metrics_filtered, size_weights_filtered)
+                        wmean, wstd = weighted_avg_and_std(
+                            metrics_filtered, size_weights_filtered
+                        )
+                        CI = confidence_interval(
+                            metrics_filtered, size_weights_filtered
+                        )
 
                     model_metrics[f"wmean_{metric}"] = wmean
                     model_metrics[f"CI_{metric}"] = CI
@@ -278,18 +286,24 @@ if __name__ == "__main__":
 
             # Step 3: Add ranks to the data and sort
             for i, data in enumerate(results_data):
-                data['rank'] = int(ranks[i])
+                data["rank"] = int(ranks[i])
 
-            sorted_results = sorted(results_data, key=lambda x: x['rank'])
+            sorted_results = sorted(results_data, key=lambda x: x["rank"])
 
             # Step 4: Print the sorted table
-            print("| Model | #Params | Rank | LogLoss | RMSE(bins) | AUC | Input features |")
+            print(
+                "| Model | #Params | Rank | LogLoss | RMSE(bins) | AUC | Input features |"
+            )
             print("| --- | --- | --- | --- | --- | --- | --- |")
 
             for data in sorted_results:
-                logloss_mean, logloss_ci = sigdig(data['wmean_LogLoss'], data['CI_LogLoss'])
-                rmse_mean, rmse_ci = sigdig(data['wmean_RMSE(bins)'], data['CI_RMSE(bins)'])
-                auc_mean, auc_ci = sigdig(data['wmean_AUC'], data['CI_AUC'])
+                logloss_mean, logloss_ci = sigdig(
+                    data["wmean_LogLoss"], data["CI_LogLoss"]
+                )
+                rmse_mean, rmse_ci = sigdig(
+                    data["wmean_RMSE(bins)"], data["CI_RMSE(bins)"]
+                )
+                auc_mean, auc_ci = sigdig(data["wmean_AUC"], data["CI_AUC"])
 
                 result_line = (
                     f"| {data['model']} | {data['n_param']} | {data['rank']} |"
@@ -300,4 +314,4 @@ if __name__ == "__main__":
                 )
                 print(result_line)
 
-            print('')  # Add a newline for better separation between scales
+            print("")  # Add a newline for better separation between scales


### PR DESCRIPTION
The problem with using 3 different metrics is that it makes it unclear which model is the best. A simple way to solve this is to normalize weighted averages of all three metrics such that 0=best and 1=worst (the opposite for AUC), then take a simple average of that (for each algo), and then use that for ranking. This required a refactor to make sure that the outputs in the table are sorted by ranks.

While I like ranking, there are some questions and potential downsides:
1) It makes the table even more information-dense
2) Is a simple average of (normalized) log loss, RMSE and AUC really the best? Should we weigh log loss more?
3) Should we exclude RMSE-BINS-EXPLOIT from ranking?

@1DWalker your opinion is welcome

Unrelated, but let's remove # before Params, it's odd and doesn't serve a clear purpose

Example output based on 100 users:
| Algorithm | Parameters | Rank | LogLoss | RMSE(bins) | AUC | Input features |
| --- | --- | --- | --- | --- | --- | --- |
| RWKV-P | 2762884 | 1 | 0.299±0.064 | 0.0187±0.0036 | 0.838±0.021 |  |
| RWKV | 2762884 | 2 | 0.339±0.074 | 0.0461±0.0087 | 0.781±0.020 |  |
| LSTM-short-secs-equalize_test_with_non_secs | 8869 | 3 | 0.355±0.076 | 0.0493±0.0098 | 0.737±0.029 | FIL, G, SR, AT |
| FSRS-rs | 21 | 4 | 0.367±0.079 | 0.059±0.012 | 0.713±0.028 | IL, G, SR |
| FSRS-6-recency | 21 | 5 | 0.367±0.079 | 0.059±0.012 | 0.713±0.029 | IL, G, SR |
| GRU-P-short | 297 | 6 | 0.367±0.079 | 0.058±0.012 | 0.705±0.035 | IL, G, SR |
| FSRS-6 | 21 | 7 | 0.369±0.080 | 0.062±0.012 | 0.711±0.027 | IL, G, SR |
| FSRS-6-preset | 21 | 8 | 0.370±0.082 | 0.063±0.014 | 0.709±0.028 | IL, G, SR |
| GRU-P | 297 | 9 | 0.375±0.082 | 0.059±0.011 | 0.693±0.034 | IL, G |
| FSRS-5 | 19 | 10 | 0.376±0.079 | 0.069±0.012 | 0.708±0.028 | IL, G, SR |
| FSRS-6-binary | 17 | 11 | 0.374±0.081 | 0.065±0.012 | 0.692±0.031 | IL, G, SR |
| FSRS-4.5 | 17 | 12 | 0.382±0.083 | 0.070±0.011 | 0.695±0.027 | IL, G |
| FSRS-6-pretrain | 4 | 13 | 0.385±0.081 | 0.083±0.020 | 0.711±0.023 | IL, G, SR |
| FSRSv4 | 17 | 14 | 0.392±0.087 | 0.077±0.014 | 0.695±0.025 | IL, G |
| FSRS-6-deck | 21 | 15 | 0.391±0.094 | 0.082±0.030 | 0.697±0.034 | IL, G, SR |
| GRU | 39 | 16 | 0.395±0.086 | 0.081±0.014 | 0.683±0.024 | IL, G |
| FSRS-6-dry-run | 0 | 17 | 0.404±0.093 | 0.103±0.032 | 0.710±0.029 | IL, G, SR |
| DASH[MCM] | 9 | 18 | 0.392±0.088 | 0.085±0.018 | 0.655±0.027 | IL, G |
| DASH | 9 | 19 | 0.392±0.086 | 0.082±0.016 | 0.636±0.036 | IL, G |
| DASH[ACT-R] | 5 | 20 | 0.396±0.089 | 0.088±0.020 | 0.629±0.030 | IL, G |
| DASH-short | 9 | 21 | 0.396±0.086 | 0.088±0.021 | 0.623±0.035 | IL, G, SR |
| FSRSv3 | 13 | 22 | 0.46±0.14 | 0.098±0.023 | 0.679±0.028 | IL, G |
| FSRSv2 | 14 | 23 | 0.47±0.13 | 0.094±0.020 | 0.667±0.028 | IL, G |
| FSRSv1 | 7 | 24 | 0.50±0.16 | 0.115±0.029 | 0.640±0.034 | IL, G |
| HLR | 3 | 25 | 0.50±0.14 | 0.126±0.024 | 0.644±0.038 | IL, G |
| ACT-R | 5 | 26 | 0.42±0.10 | 0.109±0.028 | 0.532±0.024 | IL |
| Anki | 7 | 27 | 0.51±0.14 | 0.129±0.041 | 0.625±0.029 | IL, G |
| AVG | 0 | 28 | 0.42±0.10 | 0.110±0.032 | 0.491±0.023 | --- |
| HLR-short | 3 | 29 | 0.53±0.14 | 0.141±0.030 | 0.631±0.039 | IL, G, SR |
| SM2-trainable | 6 | 30 | 0.55±0.16 | 0.146±0.030 | 0.612±0.036 | IL, G |
| Ebisu-v2 | 0 | 31 | 0.56±0.17 | 0.176±0.055 | 0.618±0.029 | IL, G |
| Anki-dry-run | 0 | 32 | 0.61±0.13 | 0.167±0.035 | 0.636±0.026 | IL, G |
| SM2-short | 0 | 33 | 0.65±0.15 | 0.166±0.048 | 0.609±0.036 | IL, G, SR |
| SM2 | 0 | 34 | 0.67±0.14 | 0.187±0.034 | 0.616±0.037 | IL, G |