### PR TITLE
Implement an easy way to run other.py on a subset of the users

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,3 +295,8 @@ Instead of using a 5-way split, train the algorithm and evaluate it on the same 
 ```bash
 python other.py --algo FSRS-6 --train_equals_test
 ```
+
+> You can limit the number of users with the --max-user-id parameter. Only users from 1 to max-user-id included will be considered.
+```bash
+python other.py --max-user-id 20
+```

--- a/config.py
+++ b/config.py
@@ -47,6 +47,14 @@ def create_parser():
     )
     parser.add_argument("--dev", action="store_true", help="for local development")
 
+    # Add this line:
+    parser.add_argument(
+        "--max-user-id",
+        type=int,
+        default=None,
+        help="maximum user ID to process (exclusive)"
+    )
+
     parser.add_argument(
         "--partitions",
         default="none",
@@ -158,6 +166,7 @@ class Config:
         self.dev_mode: bool = args.dev
         self.default_params: bool = args.default
         self.model_name: ModelName = args.algo
+        self.max_user_id: Optional[int] = args.max_user_id
         self.use_secs_intervals: bool = args.secs
         self.no_test_same_day: bool = args.no_test_same_day
         self.no_train_same_day: bool = args.no_train_same_day

--- a/config.py
+++ b/config.py
@@ -52,7 +52,7 @@ def create_parser():
         "--max-user-id",
         type=int,
         default=None,
-        help="maximum user ID to process (exclusive)"
+        help="maximum user ID to process (inclusive)"
     )
 
     parser.add_argument(

--- a/config.py
+++ b/config.py
@@ -52,7 +52,7 @@ def create_parser():
         "--max-user-id",
         type=int,
         default=None,
-        help="maximum user ID to process (inclusive)"
+        help="maximum user ID to process (inclusive)",
     )
 
     parser.add_argument(

--- a/other.py
+++ b/other.py
@@ -642,9 +642,13 @@ if __name__ == "__main__":
         sort_jsonl(raw_file)
 
     for user_id in dataset.partitioning.dictionaries[0]:
-        if user_id.as_py() in processed_user:
+        user_id_value = user_id.as_py()
+        # Add the filter here
+        if config.max_user_id is not None and user_id_value > config.max_user_id:
             continue
-        unprocessed_users.append(user_id.as_py())
+        if user_id_value in processed_user:
+            continue
+        unprocessed_users.append(user_id_value)
 
     unprocessed_users.sort()
 


### PR DESCRIPTION
Example :

```
(venv) ➜  srs-benchmark git:(feature/fsrs6-trainableinflectionpoint) ✗ python other.py --algo FSRS-6 --recency --processes 7 --max-user-id 2
Processed 2: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:20<00:00, 10.14s/it]
```