### PR TITLE
Add FSRS-7 + Logistic Regression Ensemble model

### DIFF
--- a/config.py
+++ b/config.py
@@ -39,6 +39,7 @@ ModelName = Literal[
     "MOVING-AVG",
     "90%",
     "LogisticRegression",
+    "FSRS-7-LR-Ensemble",
 ]
 
 
@@ -60,6 +61,13 @@ def create_parser():
         type=int,
         default=None,
         help="maximum user ID to process (inclusive)",
+    )
+
+    parser.add_argument(
+        "--min-user-id",
+        type=int,
+        default=None,
+        help="minimum user ID to process (inclusive)",
     )
 
     parser.add_argument(
@@ -205,6 +213,7 @@ class Config:
         self.default_params: bool = args.default
         self.model_name: ModelName = args.algo
         self.max_user_id: Optional[int] = args.max_user_id
+        self.min_user_id: Optional[int] = args.min_user_id
         self.use_secs_intervals: bool = args.secs
         self.lstm_use_duration: bool = args.duration
         self.no_test_same_day: bool = args.no_test_same_day

--- a/config.py
+++ b/config.py
@@ -64,13 +64,6 @@ def create_parser():
     )
 
     parser.add_argument(
-        "--min-user-id",
-        type=int,
-        default=None,
-        help="minimum user ID to process (inclusive)",
-    )
-
-    parser.add_argument(
         "--partitions",
         default="none",
         choices=["none", "deck", "preset"],
@@ -213,7 +206,6 @@ class Config:
         self.default_params: bool = args.default
         self.model_name: ModelName = args.algo
         self.max_user_id: Optional[int] = args.max_user_id
-        self.min_user_id: Optional[int] = args.min_user_id
         self.use_secs_intervals: bool = args.secs
         self.lstm_use_duration: bool = args.duration
         self.no_test_same_day: bool = args.no_test_same_day

--- a/evaluate.py
+++ b/evaluate.py
@@ -119,7 +119,12 @@ if __name__ == "__main__":
             ("MOVING-AVG", 0, "---"),
             (
                 "LogisticRegression-short-secs-recency-equalize_test_with_non_secs",
-                34,
+                35,
+                "IL, FIL, G, SR",
+            ),
+            (
+                "FSRS-7-LR-Ensemble-short-secs-equalize_test_with_non_secs",
+                72,
                 "IL, FIL, G, SR",
             ),
             ("FSRS-7-short-secs-recency-equalize_test_with_non_secs", 35, "FIL, G, SR"),
@@ -168,7 +173,7 @@ if __name__ == "__main__":
             ("RWKV-short-secs", 2762884, "[Yes](#features-note)"),
             ("LSTM-short-secs-duration", 8869, "FIL, G, SR, AT"),
             ("GRU-short-secs", 503, "FIL, G, SR"),
-            ("LogisticRegression-short-secs-recency", 34, "IL, FIL, G, SR"),
+            ("LogisticRegression-short-secs-recency", 35, "IL, FIL, G, SR"),
             ("FSRS-7-short-secs-recency", 35, "FIL, G, SR"),
             ("FSRS-7-short-secs", 35, "FIL, G, SR"),
             ("FSRS-7-sched_penalties-short-secs", 35, "FIL, G, SR"),

--- a/evaluate.py
+++ b/evaluate.py
@@ -119,12 +119,12 @@ if __name__ == "__main__":
             ("MOVING-AVG", 0, "---"),
             (
                 "LogisticRegression-short-secs-recency-equalize_test_with_non_secs",
-                35,
+                34,
                 "IL, FIL, G, SR",
             ),
             (
                 "FSRS-7-LR-Ensemble-short-secs-equalize_test_with_non_secs",
-                72,
+                71,
                 "IL, FIL, G, SR",
             ),
             ("FSRS-7-short-secs-recency-equalize_test_with_non_secs", 35, "FIL, G, SR"),
@@ -173,7 +173,7 @@ if __name__ == "__main__":
             ("RWKV-short-secs", 2762884, "[Yes](#features-note)"),
             ("LSTM-short-secs-duration", 8869, "FIL, G, SR, AT"),
             ("GRU-short-secs", 503, "FIL, G, SR"),
-            ("LogisticRegression-short-secs-recency", 35, "IL, FIL, G, SR"),
+            ("LogisticRegression-short-secs-recency", 34, "IL, FIL, G, SR"),
             ("FSRS-7-short-secs-recency", 35, "FIL, G, SR"),
             ("FSRS-7-short-secs", 35, "FIL, G, SR"),
             ("FSRS-7-sched_penalties-short-secs", 35, "FIL, G, SR"),

--- a/features/factory.py
+++ b/features/factory.py
@@ -1,4 +1,5 @@
 from features.logistic_regression_engineer import LogisticRegressionEngineer
+from features.fsrs7_lr_ensemble_engineer import FSRS7LREnsembleEngineer
 
 from .base import BaseFeatureEngineer
 from .fsrs_engineer import FSRSFeatureEngineer
@@ -39,6 +40,7 @@ FEATURE_ENGINEER_REGISTRY: dict[ModelName, Type[BaseFeatureEngineer]] = {
     "90%": FSRSFeatureEngineer,
     # Specialized models
     "LogisticRegression": LogisticRegressionEngineer,
+    "FSRS-7-LR-Ensemble": FSRS7LREnsembleEngineer,
     "GRU": LSTMFeatureEngineer,
     "LSTM": LSTMFeatureEngineer,
     "HLR": HLRFeatureEngineer,

--- a/features/fsrs7_lr_ensemble_engineer.py
+++ b/features/fsrs7_lr_ensemble_engineer.py
@@ -1,0 +1,42 @@
+from typing import Any, cast
+import pandas as pd
+import torch
+
+from .base import BaseFeatureEngineer
+from models import logistic_regression
+
+
+class FSRS7LREnsembleEngineer(BaseFeatureEngineer):
+    """Feature engineer for FSRS-7 + LR Ensemble.
+
+    Builds both FSRS-7 tensors and Logistic Regression features.
+    Always creates ``delta_t_secs`` so that LR features work
+    regardless of the ``--secs`` flag.
+    """
+
+    def _process_time_intervals(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = super()._process_time_intervals(df)
+        # LR features require fractional-day intervals even without --secs
+        if "delta_t_secs" not in df.columns and "elapsed_seconds" in df.columns:
+            df["delta_t_secs"] = (df["elapsed_seconds"] / 86400).clip(lower=0)
+        return df
+
+    def _model_specific_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        t_history_list, r_history_list = self.get_history_lists(df)
+        cast(Any, df)["tensor"] = [
+            torch.tensor((t_item[:-1], r_item[:-1]), dtype=torch.float32).transpose(0, 1)
+            for t_sublist, r_sublist in zip(t_history_list, r_history_list)
+            for t_item, r_item in zip(t_sublist, r_sublist)
+        ]
+        df["feature_rating"] = df.groupby("card_id")["rating"].shift(1).fillna(0)
+        return df
+
+    def _model_specific_postprocessing(self, df: pd.DataFrame) -> pd.DataFrame:
+        x = logistic_regression.create_features(df)
+        df = pd.concat([df, x], axis=1)
+        return df
+
+    def _compute_histories(self, df: pd.DataFrame) -> pd.DataFrame:
+        if self.config.use_secs_intervals:
+            df["delta_t"] = df["delta_t_secs"]
+        return df

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -22,6 +22,7 @@ from .nn_17 import NN_17
 from .sm2_trainable import SM2
 from .anki import Anki
 from .constant import ConstantModel
+from .fsrs7_lr_ensemble import FSRS7LREnsemble
 
 # Import Protocol for type checking
 from .trainable import TrainableModel
@@ -51,5 +52,6 @@ __all__ = [
     "SM2",
     "Anki",
     "ConstantModel",
+    "FSRS7LREnsemble",
     "TrainableModel",  # Protocol for type checking
 ]

--- a/models/fsrs7_lr_ensemble.py
+++ b/models/fsrs7_lr_ensemble.py
@@ -1,0 +1,215 @@
+import copy
+import numpy as np
+import torch
+import pandas as pd
+from typing import Any, Optional, Dict
+
+from config import Config
+from models.base import BaseModel
+from models.fsrs_v7 import FSRS7
+from models.logistic_regression import LogisticRegression
+
+
+class FSRS7LREnsemble(BaseModel):
+    """Ensemble of FSRS-7 and Logistic Regression via logit-space blending.
+
+    Blending weights are optimized on out-of-sample predictions from a
+    temporal holdout (last 30% of training data) using
+    ``scipy.optimize.minimize_scalar`` with an L2 prior centered at 0.4
+    to regularize toward equal weighting on small datasets. Final base
+    models are retrained on the full training set. Weights are clamped to
+    [0.1, 0.9] to ensure neither model is fully ignored.
+
+    Separate weights are learned for same-day and non-same-day reviews.
+    """
+
+    PRIOR = np.array([0.4, 0.4])
+
+    def __init__(self, config: Config, state_dict: Optional[Dict[str, Any]] = None):
+        super().__init__(config)
+
+        self.fsrs_config = copy.deepcopy(config)
+        self.fsrs_config.model_name = "FSRS-7"
+
+        self.lr_config = copy.deepcopy(config)
+        self.lr_config.model_name = "LogisticRegression"
+
+        if state_dict is not None:
+            self.weights = state_dict
+        else:
+            self.weights = {"fsrs_w": None, "lr_state": None}
+
+    # ── helpers ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _to_logits(arr):
+        a = np.clip(np.asarray(arr, dtype=np.float64), 1e-7, 1 - 1e-7)
+        return np.log(a / (1.0 - a))
+
+    @staticmethod
+    def _sigmoid(x):
+        return 1.0 / (1.0 + np.exp(-np.clip(x, -30, 30)))
+
+    W_MIN, W_MAX = 0.1, 0.9
+
+    @classmethod
+    def _fit_weight(cls, logit_fsrs, logit_lr, y):
+        """Find the blending weight w that minimizes BCE + L2 prior on a holdout."""
+        from scipy.optimize import minimize_scalar
+
+        prior_w = 0.4
+        n = len(y)
+        reg = max(1.0 / max(n, 1), 1e-3)
+
+        def loss_fn(w):
+            logit = w * logit_fsrs + (1.0 - w) * logit_lr
+            p = cls._sigmoid(logit)
+            p = np.clip(p, 1e-7, 1 - 1e-7)
+            bce = -np.mean(y * np.log(p) + (1 - y) * np.log(1 - p))
+            return bce + reg * (w - prior_w) ** 2
+
+        result = minimize_scalar(
+            loss_fn, bounds=(cls.W_MIN, cls.W_MAX), method="bounded"
+        )
+        return float(result.x)
+
+    # ── logit blending ─────────────────────────────────────────────────
+
+    def _ensemble_logits(self, logit_fsrs, logit_lr, is_same_day):
+        w_nsd = self.weights.get("w_fsrs_nsd", self.PRIOR[0])
+        w_sd = self.weights.get("w_fsrs_sd", self.PRIOR[1])
+        w = np.where(is_same_day, w_sd, w_nsd)
+        return w * logit_fsrs + (1.0 - w) * logit_lr
+
+    # ── training ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _trainer_cls():
+        import sys
+
+        for module_name in ("__main__", "__mp_main__", "script"):
+            module = sys.modules.get(module_name)
+            if module is not None and hasattr(module, "Trainer"):
+                return getattr(module, "Trainer")
+        raise RuntimeError("Trainer is not available in the current process")
+
+    def _train_fsrs(self, df: pd.DataFrame):
+        fsrs_model = FSRS7(config=self.fsrs_config)
+        trainer = self._trainer_cls()(
+            model=fsrs_model,
+            train_set=df,
+            test_set=None,
+            batch_size=self.fsrs_config.batch_size,
+        )
+        return trainer.train()
+
+    def _train_lr(self, df: pd.DataFrame):
+        return LogisticRegression(config=self.lr_config).optimize(df.copy())
+
+    def _fit_blending_weights(self, train_df: pd.DataFrame, val_df: pd.DataFrame):
+        from utils import Collection
+
+        fsrs_w = self._train_fsrs(train_df)
+        lr_state = self._train_lr(train_df)
+
+        fsrs_model = FSRS7(config=self.fsrs_config, w=fsrs_w)
+        fsrs_ret, _, _ = Collection(fsrs_model, self.fsrs_config).batch_predict(val_df)
+        logit_fsrs = self._to_logits(np.array(fsrs_ret))
+
+        lr_model = LogisticRegression(config=self.lr_config, state_dict=lr_state)
+        logit_lr = self._to_logits(lr_model.predict(val_df).cpu().numpy())
+
+        y_val = val_df["y"].values.astype(np.float64)
+        is_same_day = (val_df["delta_t_int"].values == 0).astype(bool)
+        nsd_mask = ~is_same_day
+
+        w_nsd = self.PRIOR[0]
+        if np.sum(nsd_mask) >= 10:
+            w_nsd = self._fit_weight(
+                logit_fsrs[nsd_mask], logit_lr[nsd_mask], y_val[nsd_mask]
+            )
+
+        w_sd = self.PRIOR[1]
+        if np.sum(is_same_day) >= 10:
+            w_sd = self._fit_weight(
+                logit_fsrs[is_same_day], logit_lr[is_same_day], y_val[is_same_day]
+            )
+
+        return w_nsd, w_sd
+
+    def optimize(self, df: pd.DataFrame) -> Dict[str, Any]:
+        n = len(df)
+        val_start = max(1, int(n * 0.7))
+        w_nsd, w_sd = self.PRIOR
+
+        if n - val_start >= 10:
+            train_df = df.iloc[:val_start].copy()
+            val_df = df.iloc[val_start:].copy()
+            w_nsd, w_sd = self._fit_blending_weights(train_df, val_df)
+
+        fsrs_w = self._train_fsrs(df)
+        lr_state = self._train_lr(df)
+
+        self.weights = {
+            "fsrs_w": fsrs_w,
+            "lr_state": lr_state,
+            "w_fsrs_nsd": w_nsd,
+            "w_fsrs_sd": w_sd,
+        }
+        self._fsrs_model = None
+        self._lr_model = None
+        return self.weights
+
+    # ── inference ────────────────────────────────────────────────────────
+
+    def _get_sub_models(self):
+        if not hasattr(self, "_fsrs_model") or self._fsrs_model is None:
+            self._fsrs_model = FSRS7(
+                config=self.fsrs_config, w=self.weights.get("fsrs_w")
+            )
+            self._lr_model = LogisticRegression(
+                config=self.lr_config, state_dict=self.weights.get("lr_state")
+            )
+        return self._fsrs_model, self._lr_model
+
+    @torch.inference_mode()
+    def predict(self, df: pd.DataFrame) -> np.ndarray:
+        fsrs_model, lr_model = self._get_sub_models()
+        from utils import Collection
+
+        fsrs_ret, _, _ = Collection(fsrs_model, self.fsrs_config).batch_predict(df)
+        lr_ret = lr_model.predict(df).cpu().numpy()
+
+        logit_fsrs = self._to_logits(np.array(fsrs_ret))
+        logit_lr = self._to_logits(np.array(lr_ret))
+        is_same_day = (df["delta_t_int"].values == 0).astype(np.float64)
+
+        logit_ens = self._ensemble_logits(logit_fsrs, logit_lr, is_same_day)
+        preds = self._sigmoid(logit_ens)
+        return np.clip(preds, 1e-7, 1 - 1e-7)
+
+    # ── serialization ────────────────────────────────────────────────────
+
+    def benchmark_state(self) -> Dict[str, Any]:
+        return self.weights
+
+    def log(self, x: Dict[str, Any]) -> None:
+        params = []
+        fsrs_w = self.weights.get("fsrs_w")
+        if fsrs_w is not None:
+            params.extend([round(p, 4) for p in fsrs_w])
+        lr_state = self.weights.get("lr_state")
+        if lr_state is not None:
+            lr_model = LogisticRegression(config=self.lr_config, state_dict=lr_state)
+            params.extend([round(p, 4) for p in lr_model.coefficients.tolist()])
+        params.append(round(self.weights.get("w_fsrs_nsd", self.PRIOR[0]), 4))
+        params.append(round(self.weights.get("w_fsrs_sd", self.PRIOR[1]), 4))
+        x["parameters"] = params
+
+    def load_state_dict(
+        self, state_dict: Dict[str, Any], strict: bool = True, assign: bool = False
+    ) -> Any:
+        self.weights = state_dict
+        self._fsrs_model = None
+        self._lr_model = None
+        return self

--- a/models/fsrs7_lr_ensemble.py
+++ b/models/fsrs7_lr_ensemble.py
@@ -23,6 +23,7 @@ class FSRS7LREnsemble(BaseModel):
     Separate weights are learned for same-day and non-same-day reviews.
     """
 
+    Trainer: Any = None
     PRIOR = np.array([0.4, 0.4])
 
     def __init__(self, config: Config, state_dict: Optional[Dict[str, Any]] = None):
@@ -83,19 +84,11 @@ class FSRS7LREnsemble(BaseModel):
 
     # ── training ─────────────────────────────────────────────────────────
 
-    @staticmethod
-    def _trainer_cls():
-        import sys
-
-        for module_name in ("__main__", "__mp_main__", "script"):
-            module = sys.modules.get(module_name)
-            if module is not None and hasattr(module, "Trainer"):
-                return getattr(module, "Trainer")
-        raise RuntimeError("Trainer is not available in the current process")
-
     def _train_fsrs(self, df: pd.DataFrame):
+        if self.Trainer is None:
+            raise RuntimeError("Trainer must be registered before optimizing the ensemble")
         fsrs_model = FSRS7(config=self.fsrs_config)
-        trainer = self._trainer_cls()(
+        trainer = self.Trainer(
             model=fsrs_model,
             train_set=df,
             test_set=None,
@@ -182,7 +175,7 @@ class FSRS7LREnsemble(BaseModel):
 
         logit_fsrs = self._to_logits(np.array(fsrs_ret))
         logit_lr = self._to_logits(np.array(lr_ret))
-        is_same_day = (df["delta_t_int"].values == 0).astype(np.float64)
+        is_same_day = df["delta_t_int"].values == 0
 
         logit_ens = self._ensemble_logits(logit_fsrs, logit_lr, is_same_day)
         preds = self._sigmoid(logit_ens)

--- a/models/logistic_regression.py
+++ b/models/logistic_regression.py
@@ -48,6 +48,7 @@ def create_features(df):
     32. [first_rating > 1] * log(1 + cumulative non-same-day fails)
     33. [first_rating > 1] * log(1 + cumulative same-day count)
     34. [first_rating > 1] * log(1 + cumulative non-same-day count)
+    35. (1 - has_passed) * log(1 + cumulative same-day fails)
     """
     df = df.copy()
     g = df.groupby("card_id", sort=False)
@@ -167,6 +168,7 @@ def create_features(df):
             (first_r > 1) * np.log1p(num_nsd_fail),
             (first_r > 1) * np.log1p(num_same_day),
             (first_r > 1) * np.log1p(num_non_same_day),
+            (1.0 - has_passed) * np.log1p(num_same_day_fail),
         ],
         axis=1,
     )
@@ -245,6 +247,7 @@ class LogisticRegression(BaseModel):
                 -0.3521,
                 -0.1613,
                 -0.1758,
+                0.0,
             ]
         )
         self.register_buffer("mean", mean)
@@ -284,6 +287,7 @@ class LogisticRegression(BaseModel):
                 0.1913,
                 0.1372,
                 0.0783,
+                0.5,
             ]
         )
         self.register_buffer("std", std)

--- a/models/logistic_regression.py
+++ b/models/logistic_regression.py
@@ -48,7 +48,6 @@ def create_features(df):
     32. [first_rating > 1] * log(1 + cumulative non-same-day fails)
     33. [first_rating > 1] * log(1 + cumulative same-day count)
     34. [first_rating > 1] * log(1 + cumulative non-same-day count)
-    35. (1 - has_passed) * log(1 + cumulative same-day fails)
     """
     df = df.copy()
     g = df.groupby("card_id", sort=False)
@@ -168,7 +167,6 @@ def create_features(df):
             (first_r > 1) * np.log1p(num_nsd_fail),
             (first_r > 1) * np.log1p(num_same_day),
             (first_r > 1) * np.log1p(num_non_same_day),
-            (1.0 - has_passed) * np.log1p(num_same_day_fail),
         ],
         axis=1,
     )
@@ -247,7 +245,6 @@ class LogisticRegression(BaseModel):
                 -0.3521,
                 -0.1613,
                 -0.1758,
-                0.0,
             ]
         )
         self.register_buffer("mean", mean)
@@ -287,7 +284,6 @@ class LogisticRegression(BaseModel):
                 0.1913,
                 0.1372,
                 0.0783,
-                0.5,
             ]
         )
         self.register_buffer("std", std)

--- a/models/model_factory.py
+++ b/models/model_factory.py
@@ -24,6 +24,7 @@ MODEL_REGISTRY: dict[ModelName, Any] = {
     "RNN": RNN,
     "GRU": GRU,
     "LogisticRegression": LogisticRegression,
+    "FSRS-7-LR-Ensemble": FSRS7LREnsemble,
     "LSTM": LSTM,
     "Transformer": Transformer,
     "NN-17": NN_17,
@@ -117,6 +118,7 @@ def create_model(
         instance = model_cls(**constructor_kwargs)  # type: ignore
     elif model_name in [
         "LogisticRegression",
+        "FSRS-7-LR-Ensemble",
     ]:
         constructor_kwargs["state_dict"] = model_params  # type: ignore
         instance = model_cls(**constructor_kwargs)  # type: ignore

--- a/script.py
+++ b/script.py
@@ -319,6 +319,8 @@ def _fit_trainable_weights(train_df: pd.DataFrame) -> Any:
             torch.mps.empty_cache()
         return weights
     elif config.model_name in ["LogisticRegression", "FSRS-7-LR-Ensemble"]:
+        if config.model_name == "FSRS-7-LR-Ensemble":
+            cast(Any, model).Trainer = Trainer
         return cast(Any, model).optimize(train_df)
 
     trainer = Trainer(
@@ -494,8 +496,6 @@ def process(
     )
     if config.model_name in ["LogisticRegression", "FSRS-7-LR-Ensemble"] and model is not None:
         cast(Any, model).log(stats)
-    import gc
-    gc.collect()
     return stats, raw
 
 
@@ -523,8 +523,6 @@ if __name__ == "__main__":
         user_id_value = user_id.as_py()
         # Add the filter here
         if config.max_user_id is not None and user_id_value > config.max_user_id:
-            continue
-        if config.min_user_id is not None and user_id_value < config.min_user_id:
             continue
         if user_id_value in processed_user:
             continue

--- a/script.py
+++ b/script.py
@@ -318,7 +318,7 @@ def _fit_trainable_weights(train_df: pd.DataFrame) -> Any:
         if config.device.type == "mps":
             torch.mps.empty_cache()
         return weights
-    elif config.model_name == "LogisticRegression":
+    elif config.model_name in ["LogisticRegression", "FSRS-7-LR-Ensemble"]:
         return cast(Any, model).optimize(train_df)
 
     trainer = Trainer(
@@ -462,7 +462,7 @@ def process(
         for partition in testset["partition"].unique():
             partition_testset = testset[testset["partition"] == partition].copy()
             weights = w.get(partition, None)
-            if config.model_name == "LogisticRegression":
+            if config.model_name in ["LogisticRegression", "FSRS-7-LR-Ensemble"]:
                 model = create_model(config, weights)
                 retentions = cast(Any, model).predict(partition_testset)
                 partition_testset["p"] = retentions
@@ -492,8 +492,10 @@ def process(
     stats, raw = evaluate(
         y, p, save_tmp_df, config.get_evaluation_file_name(), user_id, config, w_list
     )
-    if config.model_name == "LogisticRegression" and model is not None:
+    if config.model_name in ["LogisticRegression", "FSRS-7-LR-Ensemble"] and model is not None:
         cast(Any, model).log(stats)
+    import gc
+    gc.collect()
     return stats, raw
 
 
@@ -521,6 +523,8 @@ if __name__ == "__main__":
         user_id_value = user_id.as_py()
         # Add the filter here
         if config.max_user_id is not None and user_id_value > config.max_user_id:
+            continue
+        if config.min_user_id is not None and user_id_value < config.min_user_id:
             continue
         if user_id_value in processed_user:
             continue


### PR DESCRIPTION
## Summary

This PR adds a new experimental algorithm, **FSRS-7-LR-Ensemble**, that blends FSRS-7 and Logistic Regression predictions in logit space.

The main goal is to test whether a small linear feature-based model can complement FSRS-7 on some user histories while keeping the implementation relatively simple and the parameter count low.

Implementation details:

- Train temporary FSRS-7 and Logistic Regression models on the first 70% of the per-user training fold
- Fit same-day and non-same-day blending weights on the last 30% temporal holdout using out-of-sample predictions
- Retrain final FSRS-7 and Logistic Regression models on the full per-user training fold
- Blend final test predictions in logit space
- Regularize blending weights toward 0.4 and clamp them to `[0.1, 0.9]`

This replaces my earlier PR #332 with a cleaner branch rebased on the latest `main` and avoids fitting blending weights on predictions from models that already saw the holdout rows.

Related issue: #331

## Parameters

The logged parameter count is 71:

- 35 FSRS-7 parameters
- 34 Logistic Regression coefficients
- 2 blending weights (`w_fsrs_nsd`, `w_fsrs_sd`)

## Local validation

I ran a local validation on 500 sampled users from the 10k dataset, using seed = 2026 and explicitly including one previously problematic user (`241`). Both models were run on the same 500 users with:

```bash
python script.py --algo FSRS-7 --short --secs --equalize_test_with_non_secs
python script.py --algo FSRS-7-LR-Ensemble --short --secs --equalize_test_with_non_secs
```

Weighted by reviews on those 500 users:

| Metric | FSRS-7 | FSRS-7-LR-Ensemble | Delta |
|---|---:|---:|---:|
| LogLoss ↓ | 0.3062 | 0.3024 | -0.0038 |
| RMSE(bins) ↓ | 0.0466 | 0.0422 | -0.0044 |
| AUC ↑ | 0.7085 | 0.7158 | +0.0073 |
| MBE | 0.0034 | 0.0037 | +0.0003 |

Weighted by users on the same sample:

| Metric | FSRS-7 | FSRS-7-LR-Ensemble | Delta |
|---|---:|---:|---:|
| LogLoss ↓ | 0.3406 | 0.3359 | -0.0047 |
| RMSE(bins) ↓ | 0.0649 | 0.0604 | -0.0045 |
| AUC ↑ | 0.7048 | 0.7119 | +0.0071 |
| MBE | 0.0035 | 0.0035 | +0.0000 |

Per-user wins on the 500-user sample:

- LogLoss: 412 / 500
- RMSE(bins): 397 / 500
- AUC: 380 / 500
- absolute MBE: 342 / 500

Important caveat: this is still only a sampled local benchmark, not the full 10k-user benchmark. The ensemble also still underperforms FSRS-7 on some individual users. For example, user `241` remains worse for the ensemble, especially on AUC, so I do not want to overstate the result. The sample suggests the method may help on average, but a full benchmark is needed before drawing a strong conclusion.

## Test plan

- [x] Ran FSRS-7 and FSRS-7-LR-Ensemble through `script.py` on 500 sampled users
- [x] Included previously problematic user `241` in the sample
- [x] Confirmed the ensemble produces 71 logged parameters
- [x] Confirmed blending weights stay within `[0.1, 0.9]`
- [x] Confirmed changed Python files compile locally
- [x] Addressed Gemini review feedback about `Trainer` registration and boolean mask handling
- [ ] Full 10k-user benchmark

I am happy to revise or simplify the implementation if this approach does not fit the benchmark design, or if you would prefer a different validation protocol for ensemble/stacking models.