### PR TITLE
docs: fix LSTM pretrain command

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,5 +329,17 @@ Run `uv run script.py --help` for the full list. Common options include:
 To pretrain LSTM on multiple users, run:
 
 ```bash
-uv run pretrain.py --algo LSTM
+uv run reptile_trainer.py --algo LSTM
+```
+
+To tune the LSTM Reptile finetuning hyperparameters, run:
+
+```bash
+uv run reptile_optuna.py --algo LSTM
+```
+
+`pretrain.py` is used for models that support direct pooled pretraining, such as `FSRS-6`, `RNN`, `Transformer`, and `NN-17`:
+
+```bash
+uv run pretrain.py --algo FSRS-6
 ```


### PR DESCRIPTION
## Summary

- Fix the README LSTM pretraining command to use `reptile_trainer.py`.
- Add the related `reptile_optuna.py` command for LSTM Reptile finetuning hyperparameter tuning.
- Clarify that `pretrain.py` is for directly supported pooled-pretraining models.

Fixes #317.

## Validation

- `python -m py_compile pretrain.py reptile_trainer.py reptile_optuna.py`
- LSTM Reptile smoke train with real parquet users completed 2 outer-loop steps.
- `uv run` LSTM entry smoke check loaded `LSTM_opt_pretrain.pth` and processed `user_id=9000`.
