### PR TITLE
Hide the GPU from workers of CPU-only algorithms

### DIFF
--- a/script.py
+++ b/script.py
@@ -637,6 +637,18 @@ if __name__ == "__main__":
     # wall time of the parallel compute block (per-user work + scheduling, incl. LPT).
     # stderr-only; never touches outputs -> bit-for-bit correctness-neutral.
     _srsb_t0 = time.perf_counter() if os.environ.get("SRSB_TIMING") == "1" else None
+
+    # CPU-only algorithms never use the GPU (config.py puts only the neural models on
+    # CUDA), but torch.compile probes the GPU during setup, so with --compile every worker
+    # creates a CUDA context and holds VRAM for nothing. Hide the GPU from the workers.
+    # This must be set here, in the parent: spawned workers re-import this module and call
+    # torch.cuda.is_available() in Config() before any worker-side code runs, and CUDA
+    # reads this variable only once, when it initialises. Outputs are unaffected -- the
+    # device is "cpu" either way.
+    # pyrefly: ignore [missing-attribute]
+    if config.device.type == "cpu":
+        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
     with ProcessPoolExecutor(max_workers=config.num_processes) as executor:
         futures = [
             executor.submit(


### PR DESCRIPTION
* With --compile, torch.compile probes the GPU during setup, so every worker of a CPU-only algorithm (the FSRS family, DASH, HLR, etc.) created a CUDA context and held VRAM for nothing. The waste scales with --processes, since each worker holds its own context
* Fix: script.py sets CUDA_VISIBLE_DEVICES=-1 before creating the worker pool when config.device is CPU. GPU models (GRU, LSTM, RNN, NN-17, Transformer) are untouched
* The variable must be set in the parent: spawned workers re-import script.py and call torch.cuda.is_available() in Config() before any worker-side code runs, and CUDA reads the variable only once
* Only torch.compile creates the context. torch.cuda.is_available() and torch.manual_seed alone do not (checked per process with nvidia-smi)
* Verified bit-identical vs main on 10 users for FSRS-7 --recency --compile (4 runs) and HLR without --compile, and on 3 users for GRU, which still uses the GPU
* No speed change: median wall time 91.7 s with and without the change (FSRS-7, 10 users)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
